### PR TITLE
Add scripts for database backup and restore

### DIFF
--- a/imageroot/actions/restore-module/40restore_database
+++ b/imageroot/actions/restore-module/40restore_database
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e -o pipefail
+exec 1>&2 # Redirect any output to the journal (stderr)
+
+# Prepare an initialization script that restores the dump file
+mkdir -vp initdb.d
+mv -v kickstart.sql initdb.d
+#do the bash file to restore and exit once done
+cat - >initdb.d/zz_kickstart_restore.sh <<'EOS'
+# Print additional information:
+mysql --version
+# The script is sourced, override entrypoint args and exit:
+set -- true
+docker_temp_server_stop
+exit 0
+EOS
+
+# once we exit we remove initdb.d
+trap 'rm -rfv initdb.d/' EXIT
+
+# we start a container to initiate a database and load the dump
+# at the end of kickstart_restore.sh the dump is loaded and 
+# we exit the container
+podman run \
+  --rm \
+  --interactive \
+  --network=none \
+  --volume=./initdb.d:/docker-entrypoint-initdb.d:z \
+  --volume mysql-data:/var/lib/mysql/:Z \
+  --env MARIADB_ROOT_PASSWORD=Nethesis,1234 \
+  --env MARIADB_DATABASE=kickstart \
+  --env MARIADB_USER=kickstart \
+  --env MARIADB_PASSWORD=kickstart \
+  --replace --name=restore_db \
+  ${MARIADB_IMAGE}

--- a/imageroot/bin/module-cleanup-state
+++ b/imageroot/bin/module-cleanup-state
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+rm -vf kickstart.sql

--- a/imageroot/bin/module-dump-state
+++ b/imageroot/bin/module-dump-state
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+if ! systemctl --user -q is-active kickstart.service; then
+    exit 0
+fi
+
+podman exec mariadb-app mysqldump \
+        --databases kickstart \
+        --default-character-set=utf8mb4 \
+        --skip-dump-date \
+        --ignore-table=mysql.event \
+        --single-transaction \
+        --quick \
+        --add-drop-table  > kickstart.sql

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -5,5 +5,6 @@
 # List here what you want to save during backup : volumes or file Path
 
 
-#state/smarthost.env
-#volumes/html
+state/kickstart.sql
+volumes/kickstart-app
+

--- a/imageroot/systemd/user/kickstart-app.service
+++ b/imageroot/systemd/user/kickstart-app.service
@@ -21,8 +21,8 @@ ExecStartPre=-runagent discover-smarthost
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/kickstart-app.pid \
     --cidfile %t/kickstart-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/kickstart.pod-id --replace -d --name  kickstart-app \
-    --volume html:/var/www/html/:Z \
-    --volume ./config:/tmp:Z \
+    --volume kickstart-app:/var/www/html/:Z \
+    --volume ./tmp:/tmp:Z \
     --env=MARIADB_* \
     --env MARIADB_DB_TYPE=mysql \
     --env MARIADB_DB_HOST=127.0.0.1 \


### PR DESCRIPTION
This pull request adds scripts for database backup and restore. The scripts include a script to restore a database dump file, a script to clean up the module state, and a script to dump the module state. Additionally, the pull request updates the volume paths in the kickstart-app.service file.