### PR TITLE
Fix boolean values in configure-module action

### DIFF
--- a/imageroot/actions/restore-module/50traefik
+++ b/imageroot/actions/restore-module/50traefik
@@ -14,8 +14,8 @@ request = json.load(sys.stdin)
 renv = request['environment']
 
 configure_retval = agent.tasks.run(agent_id=os.environ['AGENT_ID'], action='configure-module', data={
-    "lets_encrypt": renv["TRAEFIK_LETS_ENCRYPT"],
+    "lets_encrypt": renv["TRAEFIK_LETS_ENCRYPT"] == "True",
     "host": renv["TRAEFIK_HOST"],
-    "http2https": renv["TRAEFIK_HTTP2HTTPS"],
+    "http2https": renv["TRAEFIK_HTTP2HTTPS"] == "True",
 })
 agent.assert_exp(configure_retval['exit_code'] == 0, "The configure-module subtask failed!")


### PR DESCRIPTION
This pull request fixes the issue with boolean values in the configure-module action. Previously, the values for "lets_encrypt" and "http2https" were not being properly converted to boolean values, causing errors in the subtask. This PR ensures that the values are correctly converted to boolean before being passed to the subtask.