### PR TITLE
Add clone-module script for Traefik

### DIFF
--- a/imageroot/actions/clone-module/50Traefik
+++ b/imageroot/actions/clone-module/50Traefik
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+
+configure_retval = agent.tasks.run(agent_id=os.environ['AGENT_ID'], action='configure-module', data={
+    "lets_encrypt": os.environ["TRAEFIK_LETS_ENCRYPT"] == "True",
+    "host": os.environ["TRAEFIK_HOST"],
+    "http2https": os.environ["TRAEFIK_HTTP2HTTPS"] == "True",
+})
+agent.assert_exp(configure_retval['exit_code'] == 0, "The configure-module subtask failed!")

--- a/imageroot/actions/clone-module/50traefik
+++ b/imageroot/actions/clone-module/50traefik
@@ -1,1 +1,0 @@
-../restore-module/50traefik


### PR DESCRIPTION
This pull request adds a new script called `50Traefik` to the `clone-module` directory. The script is responsible for configuring the Traefik module based on the provided environment variables.