### PR TITLE
Update container images and dependencies

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -39,7 +39,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@node:routeadm" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/mariadb:10.11.5 docker.io/nginx:1.27.1-alpine3.20" \
+    --label="org.nethserver.images=docker.io/mariadb:10.11.14 docker.io/nginx:1.28.0-alpine" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@carbon/icons-vue": "^10.37.0",
     "@carbon/vue": "^2.40.0",
-    "@nethserver/ns8-ui-lib": "^1.0.3",
+    "@nethserver/ns8-ui-lib": "^1.5.0",
     "await-to-js": "^3.0.0",
     "axios": "^0.21.2",
     "carbon-components": "^10.41.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1012,10 +1012,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nethserver/ns8-ui-lib@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.npmmirror.com/@nethserver/ns8-ui-lib/-/ns8-ui-lib-1.0.3.tgz#757eb077f276074c710455d8094aa2f25788da53"
-  integrity sha512-TBCNFvcovPrFpuKdyPiadstV0s0a4kUWdsnxjbiFOJ1GsAOepLt+c8S9qZubdJxaQ2frb4Cklr3G8rRQbaI5jA==
+"@nethserver/ns8-ui-lib@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.npmmirror.com/@nethserver/ns8-ui-lib/-/ns8-ui-lib-1.5.0.tgz#3b782643edf3969cd1e79a8c45a929a9c62e3399"
+  integrity sha512-ZwmuuwR1c33oKC/JsQ1NiJocnpaHMg77k5gTXkZOEFpVovu8tuoZKV0BiLeZvVeEOsUuAEttCercyG9UqvScwQ==
   dependencies:
     "@rollup/plugin-json" "^4.1.0"
     core-js "^3.15.2"


### PR DESCRIPTION
Update the container image versions for MariaDB and Nginx, and upgrade the @nethserver/ns8-ui-lib dependency to version 1.5.0.